### PR TITLE
Fix collision box to be centered

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -203,10 +203,10 @@ CapsuleCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Radius: 0.7268414
+  m_Radius: 0.7
   m_Height: 2.5870125
   m_Direction: 1
-  m_Center: {x: -0.00000008940699, y: 0.29326713, z: -0.24061738}
+  m_Center: {x: -0.00000008940699, y: 0.29326713, z: 0}
 --- !u!114 &-639539125941874452
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Systems/PlayerMovementSystem.cs
+++ b/Assets/Scripts/Systems/PlayerMovementSystem.cs
@@ -78,7 +78,8 @@ public partial struct PlayerMovementSystem : ISystem
             {
                 player.Rotation = quaternion.Euler(
                     0,
-                    player.State.isFacingRight ? 360.1f : 180.3f, 0,
+                    (player.State.isFacingRight ? 360.1f : 180.3f),
+                    0,
                     math.RotationOrder.YXZ
                 );
             }


### PR DESCRIPTION
When changing direction close to wall the collision box would end up inside the wall and shoot the player away
